### PR TITLE
Removing ignore for public/styles folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 .DS_Store
 node_modules/
-public/styles/
-


### PR DESCRIPTION
Suggesting to remove for a few reasons. Students have edited CSS
on accident and when Gulp runs it over writes their changes and
code lost.

Also, I think with not ignoring it's a visual association that
whenever SCSS compiles it has direct correlation to changing CSS
file. Ignoring makes this process not visible.
